### PR TITLE
Getting rid of smart quotes in older stat versions

### DIFF
--- a/wireless-info
+++ b/wireless-info
@@ -239,7 +239,7 @@ else
 fi
 
 printf "\n##### resolv.conf #######################\n\n"
-stat -c "[%a %U %N]" /etc/resolv.conf
+stat -c "[%a %U %N]" /etc/resolv.conf |iconv -f utf-8 -t ascii//translit
 grep -v '^#' /etc/resolv.conf
 
 printf "\n##### network managers ##################\n\n"


### PR DESCRIPTION
In Ubuntu 14.04 and presumably earlier, `stat -c "%N"` returns smart single-quotes (see https://unix.stackexchange.com/q/369657) causing the `wireless-info.txt` output file to be interpreted as UTF-8. This forces the smart quotes to neutral quotes.

Apparently by 16.04 this is fixed, but since this is a diagnostic script I figured you'd want to have maximum legacy compatibility.